### PR TITLE
made CI adjust env version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ before_script:
 - cd target
 - (echo user="$email" & echo pwd="$password" ) > app.properties
 - cd ..
+# omit tygron version in env name and mas2g env location name
+- mv tygronenv-*-jar-with-dependencies.jar tygronenv-jar-with-dependencies.jar
+- sed -i s/tygronenv-.*-jar-with-dependencies.jar/tygronenv-jar-with-dependencies.jar/g Municipality/Tygron.mas2g
 script:
 # run the Goal Test with a 60s timeout
 - timeout 60 java -cp com.github.goalhub.runtime.jar-with-dependencies_2.0.2.20160418123535.jar goal.tools.Run Municipality/test.test2g -v > result.txt || echo 0

--- a/Municipality/Tygron.mas2g
+++ b/Municipality/Tygron.mas2g
@@ -1,4 +1,4 @@
-use "tygronenv-1.0.4-jar-with-dependencies.jar" as environment 
+use "tygronenv-1.0.5-jar-with-dependencies.jar" as environment 
 	with map = "testgoalmap" .
 
 define tygronagent as agent {


### PR DESCRIPTION
 And changed env version of mas2g. Travis should run the test with the the env created by the connector fork. This fork decides which env version is used. So the mas2g should use the env that the connector gives. To solve the possible discrepancy between the version of the mas2g and that of the actual built env, an addition in the yml is made so that the name of the env and the env asked for by the mas2g are always the same on the CI.
