### PR TITLE
Adjusted travis to shared tygron fork env build and new login method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 language: java
 before_install:
-- git clone https://git@github.com/levilime/tygron.git
+- git clone https://git@github.com/levilime/contextvh.git tygron
 - cd tygron
 install:
 # build the connector, testing of the connector is done in the tygron repo CI.
 - mvn -pl "!doc" install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+- java -cp environment/target/tygronenv-*-jar-with-dependencies.jar login.Login $email $password
 - cd ..
 # move generated env jar to the same folder as the test file(s)
 - mv tygron/environment/target/tygronenv-*-jar-with-dependencies.jar .
 
 # make app.properties through travis before script start, needed for user validation
 before_script:
-- mkdir target
-- cd target
-- (echo user="$email" & echo pwd="$password" ) > app.properties
-- cd ..
 # omit tygron version in env name and mas2g env location name
 - mv tygronenv-*-jar-with-dependencies.jar tygronenv-jar-with-dependencies.jar
 - sed -i s/tygronenv-.*-jar-with-dependencies.jar/tygronenv-jar-with-dependencies.jar/g Municipality/Tygron.mas2g


### PR DESCRIPTION
The user account information is now stored by first invoking the login.Login main method of the tygron env jar with as arguments user and password. This is stored then in the registry and is accesible for the environment to use in the goal test invocation.
