### PR TITLE
Added rules to handle the new land and request percepts

### DIFF
--- a/Municipality/Tygron.mas2g
+++ b/Municipality/Tygron.mas2g
@@ -1,5 +1,5 @@
 use "tygronenv-1.0.8-jar-with-dependencies.jar" as environment 
-	with project = "vhproject" , domain = "tudelft".
+	with project = "vhproject", domain = "tudelft".
 
 define tygronagent as agent {
 	use tygron as main module.
@@ -8,5 +8,5 @@ define tygronagent as agent {
 }
 
 launchpolicy {
-	when name=Gemeente launch tygronagent.
+	when name=Municipality launch tygronagent.
 }

--- a/Municipality/Tygron.mas2g
+++ b/Municipality/Tygron.mas2g
@@ -8,5 +8,5 @@ define tygronagent as agent {
 }
 
 launchpolicy {
-	when name=Municipality launch tygronagent.
+	when name=Gemeente launch tygronagent.
 }

--- a/Municipality/dummy.pl
+++ b/Municipality/dummy.pl
@@ -6,7 +6,8 @@
 	indicatorLink/2,
 	stakeholder/4,
 	zone/5,
-	building/6.
+	building/6,
+	land/3.
 
 % we have a building if the building list has at least 1 element.
 havebuilding :- buildings([X|Y]).

--- a/Municipality/dummy.pl
+++ b/Municipality/dummy.pl
@@ -7,7 +7,8 @@
 	stakeholder/4,
 	zone/5,
 	building/6,
-	land/3.
+	land/3,
+	request/2.
 
 % we have a building if the building list has at least 1 element.
 havebuilding :- buildings([X|Y]).

--- a/Municipality/tygronEvents.mod2g
+++ b/Municipality/tygronEvents.mod2g
@@ -69,8 +69,8 @@ module tygronEvents {
 		do delete(request(ID,OldAnswerList)) + insert(request(ID,NewAnswerList)).
 	
 	%If requests are answered and therefore are no longer in the list, delete the request belief.
-	forall percept(requests(List)), bel(request(ID,AnswerList), not(member(request(ID,_),List))
-		do delete(request(ID,AnswerList))
+	forall percept(requests(List)), bel(request(ID,AnswerList), not(member(request(ID,_),List)))
+		do delete(request(ID,AnswerList)).
 		
 	
 	%%% Percept rules by Wouter Pasman

--- a/Municipality/tygronEvents.mod2g
+++ b/Municipality/tygronEvents.mod2g
@@ -44,7 +44,7 @@ module tygronEvents {
 	%%% to one land with 1 ID with a bigger multipolygon).
 	
 	%If new lands appear in the list, add them to our belief base.
-	forall percept(lands(List)), bel(member(land(ID,OwnerID,MultiPolygon),List))
+	forall percept(lands(List)), bel(member(land(ID,OwnerID,MultiPolygon),List), not(land(ID,_,_)))
 		do insert(land(ID,OwnerID,MultiPolygon)).
 		
 	%Every cycle deletes old values of the lands and inserts new information about the lands if there are any updates.
@@ -54,6 +54,23 @@ module tygronEvents {
 	%Every cycle checks if a piece of land is no longer there)
 	forall percept(lands(List)), bel(land(ID,OwnerID,OldMultiPolygon), not(member(land(ID,_,_),List)))
 		do delete(land(ID,OwnerID,OldMultiPolygon)).
+		
+	%%% Request PERCEPT
+	%%% New requests can be added and already answered requests can be removed from the percept list.
+	%%% We're not sure whether percepts can also be changed, so we're also adding that rule just to be sure.
+	%%% NOT SURE WHETHER THIS IS CORRECT, SINCE THIS IS VERSION 1.0.9
+	
+	%If new requests appear in the list, add them to our belief base.
+	forall percept(requests(List)), bel(member(request(ID,AnswerList),List), not(request(ID,_)))
+			do insert(request(ID,AnswerList)).
+	
+	%If percepts somehow get updated, delete the old belief and insert an updated one.
+	forall percept(requests(List)), bel(request(ID,OldAnswerList), member(request(ID,NewAnswerList), List))
+		do delete(request(ID,OldAnswerList)) + insert(request(ID,NewAnswerList)).
+	
+	%If requests are answered and therefore are no longer in the list, delete the request belief.
+	forall percept(requests(List)), bel(request(ID,AnswerList), not(member(request(ID,_),List))
+		do delete(request(ID,AnswerList))
 		
 	
 	%%% Percept rules by Wouter Pasman

--- a/Municipality/tygronEvents.mod2g
+++ b/Municipality/tygronEvents.mod2g
@@ -2,23 +2,25 @@ use dummy as knowledge.
 
 module tygronEvents {
 	
-	%If somehow new indicators appear in the list, add them to our belief base.
-	forall percept(indicators(List)), bel(member(indicator(ID,Current,Target),List), not(indicator(ID,_,_))) 
-		do insert(indicator(ID,Current,Target)).
+	%%% INDICATOR PERCEPT
+	%%% Indicator should not be able to be added or deleted during a session. But their current value can changed
+	%%% during session.
 		
 	%Every cycle deletes old values of the indicator and inserts the new one if there are any updates.
 	forall percept(indicators(List)), bel(indicator(ID,OldCurrent,OldTarget), member(indicator(ID,NewCurrent,NewTarget),List)) 
 		do delete(indicator(ID,OldCurrent,OldTarget)) + insert(indicator(ID,NewCurrent,NewTarget)).
-		
-	%If somehow new zones appear in the list, add them to our belief base.
-	forall percept(indicators(List)), bel(member(zone(ID,Name,Floors,Size,CategoriesList),List), not(zone(ID,_,_,_,_))) 
-		do insert(zone(ID,Name,Floors,Size,CategoriesList)).
-		
+	
+	%%% ZONE PERCEPT
+	%%% Zones should not be able to be added or deleted during a session. But they should be able to be changed.
+	
 	%Every cycle deletes old values of the zones and inserts the new one if there are any updates.
 	forall percept(zones(List)), bel(zone(ID,OldName,OldFloors,OldSize,OldCategoriesList), 
 		member(zone(ID,NewName,NewFloors,NewSize,NewCategoriesList),List)) 
 		do delete(zone(ID,OldName,OldFloors,OldSize,OldCategoriesList)) 
 		+ insert(zone(ID,NewName,NewFloors,NewSize,NewCategoriesList)).
+	
+	%%% BUILDING PERCEPT
+	%%% Buildings can be removed (destroyed), added (simply built) and changed (upgrades).
 	
 	%If new buildings appear in the list, add them to our belief base.
 	forall percept(buildings(List)), bel(member(building(ID,Name,OwnerID,ConstructionYear,CategoriesList,Floors),List), 
@@ -35,7 +37,23 @@ module tygronEvents {
 		not(member(building(ID,_,_,_,_,_),List))) do 
 		delete(building(ID,OldName,OldOwnerID,OldConstructionYear,OldCategoriesList,OldFloors)).
 	
+	%%% LAND PERCEPT
+	%%%	Lands can be added (one stakeholder could only buy one part of a patch of land of another stakeholder,
+	%%% creating 2 new patches which should have different ID's). Lands can be changed (change of owner for example).
+	%%% Lands should also be able to get deleted (2 patches of land with different ID's next to eachother could be merged
+	%%% to one land with 1 ID with a bigger multipolygon).
 	
+	%If new lands appear in the list, add them to our belief base.
+	forall percept(lands(List)), bel(member(land(ID,OwnerID,MultiPolygon),List))
+		do insert(land(ID,OwnerID,MultiPolygon)).
+		
+	%Every cycle deletes old values of the lands and inserts new information about the lands if there are any updates.
+	forall percept(lands(List)), bel(land(ID,OldOwnerID,OldMultiPolygon), member(land(ID,NewOwnerID,NewMultiPolygon), List))
+		do delete(land(ID,OldOwnerID,OldMultiPolygon)) + insert(land(ID,NewOwnerID,NewMultiPolygon)).
+	
+	%Every cycle checks if a piece of land is no longer there)
+	forall percept(lands(List)), bel(land(ID,OwnerID,OldMultiPolygon), not(member(land(ID,_,_),List)))
+		do delete(land(ID,OwnerID,OldMultiPolygon)).
 		
 	
 	%%% Percept rules by Wouter Pasman

--- a/Municipality/tygronInit.mod2g
+++ b/Municipality/tygronInit.mod2g
@@ -28,14 +28,20 @@ module tygronInit {
 			do insert(zone(ID,Name,Floors,Size,CategoriesList)).
 		
 		%%% BUILDING PERCEPT 
-		%%% Fallback insert rule, so we're sure they get inserted before going to the event module.
+		%%% Fallback insert rule, so we're sure they get inserted in the first cycle.
 		forall percept(buildings(List)), bel(member(building(ID,Name,OwnerID,ConstructionYear,CategoriesList,Floors),List))
 			do insert(building(ID,Name,OwnerID,ConstructionYear,CategoriesList,Floors)).
 		
 		%%% LAND PERCEPT
-		%%% Fallback insert rule, so we're sure they get inserted before going to the event module.
+		%%% Fallback insert rule, so we're sure they get inserted in the first cycle.
 		forall percept(lands(List)), bel(member(land(ID, OwnerID, MultiPolygon), List))
 			do insert(land(ID,OwnerID,MultiPolygon)).
+			
+		%%% REQUEST PERCEPT
+		%%% Fallback insert rule, so we're sure they get inserted in the first cycle.
+		%%  CAN BE WRONG RULE, NOT ABLE TO TEST YET.
+		forall percept(requests(List)), bel(member(request(IDType,AnswerList),List))
+			do insert(request(IDType,AnswerList)).
 		
 		%%% Code from Wouter%%%
 		% Inserts an initial belief so the send on change rules work which are mentioned in the event module.

--- a/Municipality/tygronInit.mod2g
+++ b/Municipality/tygronInit.mod2g
@@ -1,29 +1,41 @@
 use dummy as beliefs.
 
+%%% Init module is only ran once
 module tygronInit {
-		%%% Is execute when the agent starts%%%
 		
-		%%% Inserts for each stakeholder their basic information.
+		%%% STAKEHOLDER PERCEPT
+		%%% Stakeholder information doens't update during the session.
+
 		forall percept(stakeholders(List)), bel(member(SubList, List), 
 			member(stakeholder(ShID,Name,StartBudget,Income), SubList)) do insert(stakeholder(ShID,Name,StartBudget,Income)).
 		
-		%%% Inserts for each stakeholder their basic indicator information.
+		%%% INDICATORLINK PERCEPT
+		%%% Stakeholder information doens't update during the session.
+		
 		forall percept(stakeholders(List)), bel(member(SubList, List), member(indicatorLink(ShID,IndWeights), SubList)) 
 			do insert(indicatorLink(ShID,IndWeights)).
 		
-		%%% For each indicator in the game, insert its start value and target.
+		%%% INDICATOR PERCEPT
+		%%% Indicators should be initialized to be used by the rule in the event module.
+		
 		forall percept(indicators(List)), bel(member(indicator(ID,Current,Target),List))
 			do insert(indicator(ID,Current,Target)).
 		
-		%%% For each zones in the game, insert its basic information.
+		%%% ZONE PERCEPT
+		%%% For the same reason as indicator. It should be initialized before going to the event module rules.
+		
 		forall percept(zones(List)), bel(member(zone(ID,Name,Floors,Size,CategoriesList),List)) 
 			do insert(zone(ID,Name,Floors,Size,CategoriesList)).
 		
-		%%% For each new building, insert its basic information.
+		%%% BUILDING PERCEPT 
+		%%% Fallback insert rule, so we're sure they get inserted before going to the event module.
 		forall percept(buildings(List)), bel(member(building(ID,Name,OwnerID,ConstructionYear,CategoriesList,Floors),List))
 			do insert(building(ID,Name,OwnerID,ConstructionYear,CategoriesList,Floors)).
 		
-		
+		%%% LAND PERCEPT
+		%%% Fallback insert rule, so we're sure they get inserted before going to the event module.
+		forall percept(lands(List)), bel(member(land(ID, OwnerID, MultiPolygon), List))
+			do insert(land(ID,OwnerID,MultiPolygon)).
 		
 		%%% Code from Wouter%%%
 		% Inserts an initial belief so the send on change rules work which are mentioned in the event module.


### PR DESCRIPTION
User story: As a GOAL programmer, I want to be able to have the code to handle the newest percepts so I can create more advanced logic for my agent.
- Added rules for handling beliefs of the land percept, which gives all available land.
- Added rules for handling beliefs of the request percept, which gives requests with a needed answer and their possible answers.
- Added general comments on why these rules are needed.
