### PR TITLE
Changed launch policy and code to work with environment v1.0.9

### DIFF
--- a/Municipality/Tygron.mas2g
+++ b/Municipality/Tygron.mas2g
@@ -1,5 +1,5 @@
-use "tygronenv-1.0.8-jar-with-dependencies.jar" as environment 
-	with project = "vhproject", domain = "tudelft".
+use "tygronenv-1.0.9-jar-with-dependencies.jar" as environment 
+	with project = "vhprojectdanshal", stakeholders = ['Gemeente'], domain = "tudelft".
 
 define tygronagent as agent {
 	use tygron as main module.
@@ -8,5 +8,5 @@ define tygronagent as agent {
 }
 
 launchpolicy {
-	when name=Gemeente launch tygronagent.
+	when name=GEMEENTE launch tygronagent.
 }

--- a/Municipality/tygron.mod2g
+++ b/Municipality/tygron.mod2g
@@ -9,12 +9,12 @@ module tygron {
 	
 	% If there is a goal to have a park, build a park (currently not working).
 	if goal(buildPark), bel(functions(FS), member(['stadspark',Id,L],FS)) 
-		then building_plan_construction(Id, 1, square(10,10,200,10)).
+		then building_plan_construction(Id, 1, multipolygon('MULTIPOLYGON (((10 10, 10 20, 210 20, 210 10, 10 10)))')).
 	
 	% If there is a function to build a road
 	% Then use building_plan_construction to build it (always 1 floor)
 	if bel(functions(FS), member([Name,Id,L],FS), member('ROAD',L)) 
-		then building_plan_construction(Id, 1, square(10,10,200,10)).
+		then building_plan_construction(Id, 1, multipolygon('MULTIPOLYGON (((10 10, 10 20, 210 20, 210 10, 10 10)))')).
 
 
 }


### PR DESCRIPTION
User story: As a GOAL programmer, I always want to use the latest version of the environment, so I can use the newest versions of predicates.
- Changed use clause to use newer .jar file and stakeholders option.
- Removed use of square/4 since this is removed in v1.0.9
