### PR TITLE
Actionmenu percept rules added

### DIFF
--- a/Municipality/dummy.pl
+++ b/Municipality/dummy.pl
@@ -13,7 +13,8 @@
 	land/3,
 	request/2,
 	havebuiltsomething/0,
-	land/3.
+	land/3,
+	action/3.
 
 % We have a building if the building list has at least 1 element.
 havebuilding :- true.

--- a/Municipality/tygronEvents.mod2g
+++ b/Municipality/tygronEvents.mod2g
@@ -72,7 +72,29 @@ module tygronEvents {
 	%If requests are answered and therefore are no longer in the list, delete the request belief.
 	forall percept(requests(List)), bel(request(ID,AnswerList), not(member(request(ID,_),List)))
 		do delete(request(ID,AnswerList)).
-		
+	
+	%%% Action PERCEPT
+	%%% Action percept is the percept for the action_menu and gives the possible actions a stakeholder is able to perform.
+	
+	%If new actions appear in the list, add them to our belief base. The FunctionList cannot be the SpecialOptions list.
+	forall percept(actions(List)), bel(member(["action", ID, FunctionList, SpecialOptions], List), not(action(ID,_,_)), member(X, FunctionList), is_list(X))
+			do insert(action(ID,FunctionList, SpecialOptions)).
+	
+	%If new actions appear in the list, add them to our belief base. The FunctionList needs to be the SpecialOptions list.
+	forall percept(actions(List)), bel(member(["action", ID, FunctionList, SpecialOptions], List), not(action(ID,_,_)), member(X, FunctionList), not(is_list(X)))
+			do insert(action(ID,[], FunctionList)).
+	
+	%If percepts somehow get updated, delete the old belief and insert an updated one. The FunctionList cannot be the SpecialOptions list.
+	forall percept(actions(List)), bel(action(ID,OldFunctionList, OldSpecialOptions), member(["action", ID, NewFunctionList, NewSpecialOptions], List), member(X, NewFunctionList), is_list(X))
+		do delete(action(ID,OldFunctionList, OldSpecialOptions)) + insert(action(ID,NewFunctionList, NewSpecialOptions)).
+	
+	%If percepts somehow get updated, delete the old belief and insert an updated one. The FunctionList needs to be the SpecialOptions list.
+	forall percept(actions(List)), bel(action(ID,OldFunctionList, OldSpecialOptions), member(["action", ID, NewFunctionList, NewSpecialOptions], List), member(X, NewFunctionList), not(is_list(X)))
+		do delete(action(ID,OldFunctionList, OldSpecialOptions)) + insert(action(ID,[], NewFunctionList)).
+	
+	%If actions are not longer applicable and therefore are no longer in the list, delete the action belief.
+	forall percept(actions(List)), bel(action(ID,FunctionList, SpecialOptions), not(member(["action", ID, _, _], List)))
+		do delete(action(ID,FunctionList, SpecialOptions)).	
 	
 	%%% Percept rules by Wouter Pasman
 	% Deletes the old functions list and insert the new one if there is an update of the functions

--- a/Municipality/tygronEvents.mod2g
+++ b/Municipality/tygronEvents.mod2g
@@ -85,8 +85,8 @@ module tygronEvents {
 	forall percept(requests(List)), bel(request(ID,AnswerList), not(member(request(ID,_),List)))
 		do delete(request(ID,AnswerList)).
 	
-	%%% Action PERCEPT
-	%%% Action percept is the percept for the action_menu and gives the possible actions a stakeholder is able to perform.
+	%Action PERCEPT
+	%Action percept is the percept for the action_menu and gives the possible actions a stakeholder is able to perform.
 	
 	%If new actions appear in the list, add them to our belief base. The FunctionList cannot be the SpecialOptions list.
 	forall percept(actions(List)), bel(member(["action", ID, FunctionList, SpecialOptions], List), not(action(ID,_,_)), member(X, FunctionList), is_list(X))

--- a/Municipality/tygronInit.mod2g
+++ b/Municipality/tygronInit.mod2g
@@ -43,6 +43,17 @@ module tygronInit {
 		forall percept(requests(List)), bel(member(request(IDType,AnswerList),List))
 			do insert(request(IDType,AnswerList)).
 		
+		%%% ACTION PERCEPT
+		%%% Action insert rule, since the action percepts already has actions in it during the first cycle.
+		%The FunctionList cannot  be the SpecialOptions list. 
+		forall percept(actions(List)), bel(member(["action", ID, FunctionList, SpecialOptions], List), member(X, FunctionList), is_list(X))
+			do insert(action(ID, FunctionList, SpecialOptions)).
+		
+		%%% Action insert rule, since the action percepts already has actions in it during the first cycle.
+		%The FunctionList needs to be the SpecialOptions list. 
+		forall percept(actions(List)), bel(member(["action", ID, FunctionList, SpecialOptions], List), member(X, FunctionList), not(is_list(X)))
+			do insert(action(ID, [], FunctionList)).
+		
 		%%% Code from Wouter%%%
 		% Inserts an initial belief so the send on change rules work which are mentioned in the event module.
 		if true then insert(settings([])).

--- a/Municipality/tygronInit.mod2g
+++ b/Municipality/tygronInit.mod2g
@@ -49,13 +49,13 @@ module tygronInit {
 		forall percept(requests(List)), bel(member(request(IDType,AnswerList),List))
 			do insert(request(IDType,AnswerList)).
 		
-		%%% ACTION PERCEPT
-		%%% Action insert rule, since the action percepts already has actions in it during the first cycle.
+		%ACTION PERCEPT
+		%Action insert rule, since the action percepts already has actions in it during the first cycle.
 		%The FunctionList cannot  be the SpecialOptions list. 
 		forall percept(actions(List)), bel(member(["action", ID, FunctionList, SpecialOptions], List), member(X, FunctionList), is_list(X))
 			do insert(action(ID, FunctionList, SpecialOptions)).
 		
-		%%% Action insert rule, since the action percepts already has actions in it during the first cycle.
+		%Action insert rule, since the action percepts already has actions in it during the first cycle.
 		%The FunctionList needs to be the SpecialOptions list. 
 		forall percept(actions(List)), bel(member(["action", ID, FunctionList, SpecialOptions], List), member(X, FunctionList), not(is_list(X)))
 			do insert(action(ID, [], FunctionList)).


### PR DESCRIPTION
Added action_menu percept to the GOAL bot.

As a goal bot I want to  be able to see the new action_menu percept added to my belief base so that I can use it to decide on which action to perform.
