### PR TITLE
Implemented percept rule and tests for my_stakeholder_id/1

### DIFF
--- a/Municipality/dummy.pl
+++ b/Municipality/dummy.pl
@@ -15,7 +15,8 @@
 	havebuiltsomething/0,
 	land/3,
 	function/3,
-	actionlog/4.
+	actionlog/4,
+	my_stakeholder_id/1.
 
 % We have a building if the building list has at least 1 element.
 havebuilding :- true.

--- a/Municipality/test.test2g
+++ b/Municipality/test.test2g
@@ -8,6 +8,10 @@ timeout = 300.
 test tygron with
 	pre{true}
 	in{ 
+		
+		%If a percept is perceived, insert it.
+		percept(my_stakeholder_id(StakeholderID)) leadsto bel(my_stakeholder_id(StakeholderID)).
+		
 		%If a percept list is perceived, then for every member of the list, check if it is inserted as belief.
 		%These tests have been made according to the templates in the GOAL Programming guide.
 		percept(indicators(List)),bel(member(indicator(ID,Current,Target),List)) 
@@ -36,6 +40,9 @@ test tygron with
 		percept(action_logs(ActList)), bel(actionlog(StakeholderID,Description,ActionID,IncList),
 			not(member(actionlog(StakeholderID,Description,ActionID,IncList), ActList)))
 			leadsto not(bel(actionlog(StakeholderID,Description,ActionID,IncList))).
+			
+		%There are some beliefs that should never be deleted. These tests make sure that never happens.
+		never(not(bel(my_stakeholder_id(_))))).
 
 	}
 	post{true}		

--- a/Municipality/test.test2g
+++ b/Municipality/test.test2g
@@ -42,7 +42,7 @@ test tygron with
 			leadsto not(bel(actionlog(StakeholderID,Description,ActionID,IncList))).
 			
 		%There are some beliefs that should never be deleted. These tests make sure that never happens.
-		never(not(bel(my_stakeholder_id(_))))).
+		always(bel(my_stakeholder_id(_))).
 
 	}
 	post{true}		

--- a/Municipality/tygronInit.mod2g
+++ b/Municipality/tygronInit.mod2g
@@ -4,17 +4,12 @@ use dummy as beliefs.
 % Order of the module is standard linearall
 module tygronInit {
 		
-<<<<<<< HEAD
 		% MY_STAKEHOLDER_ID PERCEPT
 		% Agents don't switch from stakeholder, so this only needs to be inserted once and should never change
 		if percept(my_stakeholder_id(StakeholderID)) then insert(my_stakeholder_id(StakeholderID)).
 		
 		%%% STAKEHOLDER PERCEPT
 		%%% Stakeholder information doens't update during the session.
-=======
-		%STAKEHOLDER PERCEPT
-		%Stakeholder information doens't update during the session.
->>>>>>> refs/remotes/origin/master
 
 		forall percept(stakeholders(List)), bel(member(SubList, List), 
 			member(stakeholder(StakeholderID,Name,StartBudget,Income), SubList)) do insert(stakeholder(StakeholderID,Name,StartBudget,Income)).

--- a/Municipality/tygronInit.mod2g
+++ b/Municipality/tygronInit.mod2g
@@ -3,8 +3,14 @@ use dummy as beliefs.
 %%% Init module is only ran once
 module tygronInit {
 		
+		% MY_STAKEHOLDER_ID PERCEPT
+		% Agents don't switch from stakeholder, so this only needs to be inserted once and should never change
+		if percept(my_stakeholder_id(StakeholderID)) then insert(my_stakeholder_id(StakeholderID)).
+		
 		%%% STAKEHOLDER PERCEPT
 		%%% Stakeholder information doens't update during the session.
+		
+		if percept(my_stakeholder_id(StakeholderID)) then insert(my_stakeholder_id(StakeholderID)).
 
 		forall percept(stakeholders(List)), bel(member(SubList, List), 
 			member(stakeholder(ShID,Name,StartBudget,Income), SubList)) do insert(stakeholder(ShID,Name,StartBudget,Income)).

--- a/Municipality/tygronInit.mod2g
+++ b/Municipality/tygronInit.mod2g
@@ -1,16 +1,15 @@
 use dummy as beliefs.
 
-% The init module is ran only once at the startup of the agent.
-% Order of the module is standard linearall
+%The init module is ran only once at the startup of the agent.
+%Order of the module is standard linearall
 module tygronInit {
 		
-		% MY_STAKEHOLDER_ID PERCEPT
-		% Agents don't switch from stakeholder, so this only needs to be inserted once and should never change
+		%MY_STAKEHOLDER_ID PERCEPT
+		%Agents don't switch from stakeholder, so this only needs to be inserted once and should never change
 		if percept(my_stakeholder_id(StakeholderID)) then insert(my_stakeholder_id(StakeholderID)).
 		
-		%%% STAKEHOLDER PERCEPT
-		%%% Stakeholder information doens't update during the session.
-
+		%STAKEHOLDER PERCEPT
+		%Stakeholder information doens't update during the session.
 		forall percept(stakeholders(List)), bel(member(SubList, List), 
 			member(stakeholder(StakeholderID,Name,StartBudget,Income), SubList)) do insert(stakeholder(StakeholderID,Name,StartBudget,Income)).
 		

--- a/Municipality/tygronInit.mod2g
+++ b/Municipality/tygronInit.mod2g
@@ -9,8 +9,6 @@ module tygronInit {
 		
 		%%% STAKEHOLDER PERCEPT
 		%%% Stakeholder information doens't update during the session.
-		
-		if percept(my_stakeholder_id(StakeholderID)) then insert(my_stakeholder_id(StakeholderID)).
 
 		forall percept(stakeholders(List)), bel(member(SubList, List), 
 			member(stakeholder(ShID,Name,StartBudget,Income), SubList)) do insert(stakeholder(ShID,Name,StartBudget,Income)).


### PR DESCRIPTION
As a GOAL programmer, I want to implement the newest percepts in the environment so I can work with them.
- Added init percept rule which inserts my_stakeholder_id in our belief base
- Created some simple tests which can be extended if wanted.
